### PR TITLE
Bump `classnames` to 2.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "release": "release"
   },
   "dependencies": {
-    "classnames": "^1.1.4",
+    "classnames": "^2.2.3",
     "promise": "^7.0.3",
     "topeka": "^0.3.0"
   },


### PR DESCRIPTION
Also seems like it's used only in examples and should be a dev dependency.